### PR TITLE
Switch to using Black for formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,26 @@ on:
   - pull_request
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black==21.9b0
+
+      - name: Check formatting
+        run: |
+          black --check .
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/pyisemail/__init__.py
+++ b/pyisemail/__init__.py
@@ -7,7 +7,7 @@ from pyisemail.validators import ParserValidator
 from pyisemail.version import VERSION
 
 __version__ = VERSION
-__all__ = ['is_email']
+__all__ = ["is_email"]
 
 
 def is_email(address, check_dns=False, diagnose=False, allow_gtld=True):

--- a/pyisemail/diagnosis/__init__.py
+++ b/pyisemail/diagnosis/__init__.py
@@ -9,7 +9,12 @@ from pyisemail.diagnosis.rfc5322_diagnosis import RFC5322Diagnosis
 from pyisemail.diagnosis.valid_diagnosis import ValidDiagnosis
 
 __all__ = [
-    'BaseDiagnosis', 'CFWSDiagnosis', 'DeprecatedDiagnosis', 'DNSDiagnosis',
-    'InvalidDiagnosis', 'RFC5321Diagnosis', 'RFC5322Diagnosis',
-    'ValidDiagnosis',
+    "BaseDiagnosis",
+    "CFWSDiagnosis",
+    "DeprecatedDiagnosis",
+    "DNSDiagnosis",
+    "InvalidDiagnosis",
+    "RFC5321Diagnosis",
+    "RFC5322Diagnosis",
+    "ValidDiagnosis",
 ]

--- a/pyisemail/diagnosis/base_diagnosis.py
+++ b/pyisemail/diagnosis/base_diagnosis.py
@@ -12,14 +12,14 @@ class BaseDiagnosis(object):
     """
 
     CATEGORIES = {
-        'VALID': 1,
-        'DNSWARN': 7,
-        'RFC5321': 15,
-        'THRESHOLD': 16,
-        'CFWS': 31,
-        'DEPREC': 63,
-        'RFC5322': 127,
-        'ERR': 255,
+        "VALID": 1,
+        "DNSWARN": 7,
+        "RFC5321": 15,
+        "THRESHOLD": 16,
+        "CFWS": 31,
+        "DEPREC": 63,
+        "RFC5322": 127,
+        "ERR": 255,
     }
     DESCRIPTION = ""
     ERROR_CODES = {}

--- a/pyisemail/diagnosis/cfws_diagnosis.py
+++ b/pyisemail/diagnosis/cfws_diagnosis.py
@@ -3,24 +3,24 @@ from pyisemail.diagnosis import BaseDiagnosis
 
 class CFWSDiagnosis(BaseDiagnosis):
 
-    """A diagnosis indicating a problem with white space in the address.
+    """A diagnosis indicating a problem with white space in the address."""
 
-    """
-
-    DESCRIPTION = ("Address is valid within the message "
-                   "but cannot be used unmodified for the envelope.")
+    DESCRIPTION = (
+        "Address is valid within the message "
+        "but cannot be used unmodified for the envelope."
+    )
 
     ERROR_CODES = {
-        'COMMENT': 17,
-        'FWS': 18,
+        "COMMENT": 17,
+        "FWS": 18,
     }
 
     MESSAGES = {
-        'COMMENT': "Address contains messages",
-        'FWS': "Address contains Folding White Space",
+        "COMMENT": "Address contains messages",
+        "FWS": "Address contains Folding White Space",
     }
 
     REFERENCES = {
-        'COMMENT': ['dot-atom'],
-        'FWS': ['local-part'],
+        "COMMENT": ["dot-atom"],
+        "FWS": ["local-part"],
     }

--- a/pyisemail/diagnosis/deprecated_diagnosis.py
+++ b/pyisemail/diagnosis/deprecated_diagnosis.py
@@ -3,40 +3,41 @@ from pyisemail.diagnosis import BaseDiagnosis
 
 class DeprecatedDiagnosis(BaseDiagnosis):
 
-    """A diagnosis indicating the presence of deprecated address features.
+    """A diagnosis indicating the presence of deprecated address features."""
 
-    """
-
-    DESCRIPTION = ("Address contains deprecated elements "
-                   "but may still be valid in restricted contexts.")
+    DESCRIPTION = (
+        "Address contains deprecated elements "
+        "but may still be valid in restricted contexts."
+    )
 
     ERROR_CODES = {
-        'LOCALPART': 33,
-        'FWS': 34,
-        'QTEXT': 35,
-        'QP': 36,
-        'COMMENT': 37,
-        'CTEXT': 38,
-        'CFWS_NEAR_AT': 49,
+        "LOCALPART": 33,
+        "FWS": 34,
+        "QTEXT": 35,
+        "QP": 36,
+        "COMMENT": 37,
+        "CTEXT": 38,
+        "CFWS_NEAR_AT": 49,
     }
 
     MESSAGES = {
-        'LOCALPART': "Address contains a local part in deprecated form.",
-        'FWS': "Address contains Folding White Space in deprecated form.",
-        'QTEXT': "Address contains a quoted string in deprecated form.",
-        'QP': "Address contains a quoted pair in deprecated form.",
-        'COMMENT': "Address contains a comment in deprecated form.",
-        'CTEXT': "Address contains a comment with a deprecated character.",
-        'CFWS_NEAR_AT': ("Address contains a comment or Folding White Space "
-                         "around the @ sign."),
+        "LOCALPART": "Address contains a local part in deprecated form.",
+        "FWS": "Address contains Folding White Space in deprecated form.",
+        "QTEXT": "Address contains a quoted string in deprecated form.",
+        "QP": "Address contains a quoted pair in deprecated form.",
+        "COMMENT": "Address contains a comment in deprecated form.",
+        "CTEXT": "Address contains a comment with a deprecated character.",
+        "CFWS_NEAR_AT": (
+            "Address contains a comment or Folding White Space " "around the @ sign."
+        ),
     }
 
     REFERENCES = {
-        'LOCALPART': ['obs-local-part'],
-        'FWS': ['obs-local-part', 'obs-domain'],
-        'QTEXT': ['obs-qtext'],
-        'QP': ['obs-qp'],
-        'COMMENT': ['obs-local-part', 'obs-domain'],
-        'CTEXT': ['obs-ctext'],
-        'CFWS_NEAR_AT': ['CFWS-near-at', 'SHOULD-NOT'],
+        "LOCALPART": ["obs-local-part"],
+        "FWS": ["obs-local-part", "obs-domain"],
+        "QTEXT": ["obs-qtext"],
+        "QP": ["obs-qp"],
+        "COMMENT": ["obs-local-part", "obs-domain"],
+        "CTEXT": ["obs-ctext"],
+        "CFWS_NEAR_AT": ["CFWS-near-at", "SHOULD-NOT"],
     }

--- a/pyisemail/diagnosis/dns_diagnosis.py
+++ b/pyisemail/diagnosis/dns_diagnosis.py
@@ -3,23 +3,22 @@ from pyisemail.diagnosis import BaseDiagnosis
 
 class DNSDiagnosis(BaseDiagnosis):
 
-    """A diagnosis indicating a lack of a DNS record for a domain.
-
-    """
+    """A diagnosis indicating a lack of a DNS record for a domain."""
 
     DESCRIPTION = "Address is valid but a DNS check was not successful."
 
     ERROR_CODES = {
-        'NO_NAMESERVERS': 3,
-        'DNS_TIMEDOUT': 4,
-        'NO_MX_RECORD': 5,
-        'NO_RECORD': 6,
+        "NO_NAMESERVERS": 3,
+        "DNS_TIMEDOUT": 4,
+        "NO_MX_RECORD": 5,
+        "NO_RECORD": 6,
     }
 
     MESSAGES = {
-        'NO_NAMESERVERS': "All nameservers failed to answer the query",
-        'DNS_TIMEOUT': "The DNS query timed out",
-        'NO_MX_RECORD': ("Couldn't find an MX record for this domain "
-                         "but an A record does exist."),
-        'NO_RECORD': "Couldn't find an MX record or A record for this domain.",
+        "NO_NAMESERVERS": "All nameservers failed to answer the query",
+        "DNS_TIMEOUT": "The DNS query timed out",
+        "NO_MX_RECORD": (
+            "Couldn't find an MX record for this domain " "but an A record does exist."
+        ),
+        "NO_RECORD": "Couldn't find an MX record or A record for this domain.",
     }

--- a/pyisemail/diagnosis/invalid_diagnosis.py
+++ b/pyisemail/diagnosis/invalid_diagnosis.py
@@ -3,100 +3,110 @@ from pyisemail.diagnosis import BaseDiagnosis
 
 class InvalidDiagnosis(BaseDiagnosis):
 
-    """A diagnosis indicating the presence of an invalid address component.
-
-    """
+    """A diagnosis indicating the presence of an invalid address component."""
 
     DESCRIPTION = "Address is invalid for any purpose"
 
     ERROR_CODES = {
-        'EXPECTING_DTEXT': 129,
-        'NOLOCALPART': 130,
-        'NODOMAIN': 131,
-        'CONSECUTIVEDOTS': 132,
-        'ATEXT_AFTER_CFWS': 133,
-        'ATEXT_AFTER_QS': 134,
-        'ATEXT_AFTER_DOMLIT': 135,
-        'EXPECTING_QPAIR': 136,
-        'EXPECTING_ATEXT': 137,
-        'EXPECTING_QTEXT': 138,
-        'EXPECTING_CTEXT': 139,
-        'BACKSLASHEND': 140,
-        'DOT_START': 141,
-        'DOT_END': 142,
-        'DOMAINHYPHENSTART': 143,
-        'DOMAINHYPHENEND': 144,
-        'UNCLOSEDQUOTEDSTR': 145,
-        'UNCLOSEDCOMMENT': 146,
-        'UNCLOSEDDOMLIT': 147,
-        'FWS_CRLF_X2': 148,
-        'FWS_CRLF_END': 149,
-        'CR_NO_LF': 150,
-        'BAD_PARSE': 151,
+        "EXPECTING_DTEXT": 129,
+        "NOLOCALPART": 130,
+        "NODOMAIN": 131,
+        "CONSECUTIVEDOTS": 132,
+        "ATEXT_AFTER_CFWS": 133,
+        "ATEXT_AFTER_QS": 134,
+        "ATEXT_AFTER_DOMLIT": 135,
+        "EXPECTING_QPAIR": 136,
+        "EXPECTING_ATEXT": 137,
+        "EXPECTING_QTEXT": 138,
+        "EXPECTING_CTEXT": 139,
+        "BACKSLASHEND": 140,
+        "DOT_START": 141,
+        "DOT_END": 142,
+        "DOMAINHYPHENSTART": 143,
+        "DOMAINHYPHENEND": 144,
+        "UNCLOSEDQUOTEDSTR": 145,
+        "UNCLOSEDCOMMENT": 146,
+        "UNCLOSEDDOMLIT": 147,
+        "FWS_CRLF_X2": 148,
+        "FWS_CRLF_END": 149,
+        "CR_NO_LF": 150,
+        "BAD_PARSE": 151,
     }
 
     MESSAGES = {
-        'EXPECTING_DTEXT': ("Address contains a character that is "
-                            "not allowed in a domain literal."),
-        'NOLOCALPART': "Address has no local part.",
-        'NODOMAIN': "Address has no domain part.",
-        'CONSECUTIVEDOTS': "Address contains consecutive dots.",
-        'ATEXT_AFTER_CFWS': ("Address contains text after a comment "
-                             "or Folding White Space."),
-        'ATEXT_AFTER_QS': "Address contains text after a quoted string.",
-        'ATEXT_AFTER_DOMLIT': ("Address contains extra characters "
-                               "after the domain literal."),
-        'EXPECTING_QPAIR': ("Address contains a character that is "
-                            "not allowed in a quoted pair."),
-        'EXPECTING_ATEXT': "Address contains a character that is not allowed.",
-        'EXPECTING_QTEXT': ("Address contains a character that is "
-                            "not allowed in a quoted string."),
-        'EXPECTING_CTEXT': ("Address contains a character that is "
-                            "not allowed in a comment."),
-        'BACKSLASHEND': "Address ends in a backslash.",
-        'DOT_START': ("Address has a local part or domain "
-                      "that begins with a dot."),
-        'DOT_END': ("Address has a local part or domain "
-                    "that ends with a dot."),
-        'DOMAINHYPHENSTART': ("Address has a local part or domain "
-                              "that begins with a hyphen."),
-        'DOMAINHYPHENEND': ("Address has a local part or domain "
-                            "that ends with a hyphen."),
-        'UNCLOSEDQUOTEDSTR': "Address contains an unclosed quoted string.",
-        'UNCLOSEDCOMMENT': "Address contains an unclosed comment.",
-        'UNCLOSEDDOMLIT': ("Address contains a domain literal "
-                           "that is missing its closing bracket."),
-        'FWS_CRLF_X2': ("Address contains a Folding White Space "
-                        "that has consecutive CRLF sequences."),
-        'FWS_CRLF_END': ("Address contains a Folding White Space "
-                         "that ends with a CRLF sequence."),
-        'CR_NO_LF': ("Address contains a carriage return "
-                     "that is not followed by a line return."),
-        'BAD_PARSE': "Address is malformed.",
+        "EXPECTING_DTEXT": (
+            "Address contains a character that is " "not allowed in a domain literal."
+        ),
+        "NOLOCALPART": "Address has no local part.",
+        "NODOMAIN": "Address has no domain part.",
+        "CONSECUTIVEDOTS": "Address contains consecutive dots.",
+        "ATEXT_AFTER_CFWS": (
+            "Address contains text after a comment " "or Folding White Space."
+        ),
+        "ATEXT_AFTER_QS": "Address contains text after a quoted string.",
+        "ATEXT_AFTER_DOMLIT": (
+            "Address contains extra characters " "after the domain literal."
+        ),
+        "EXPECTING_QPAIR": (
+            "Address contains a character that is " "not allowed in a quoted pair."
+        ),
+        "EXPECTING_ATEXT": "Address contains a character that is not allowed.",
+        "EXPECTING_QTEXT": (
+            "Address contains a character that is " "not allowed in a quoted string."
+        ),
+        "EXPECTING_CTEXT": (
+            "Address contains a character that is " "not allowed in a comment."
+        ),
+        "BACKSLASHEND": "Address ends in a backslash.",
+        "DOT_START": ("Address has a local part or domain " "that begins with a dot."),
+        "DOT_END": ("Address has a local part or domain " "that ends with a dot."),
+        "DOMAINHYPHENSTART": (
+            "Address has a local part or domain " "that begins with a hyphen."
+        ),
+        "DOMAINHYPHENEND": (
+            "Address has a local part or domain " "that ends with a hyphen."
+        ),
+        "UNCLOSEDQUOTEDSTR": "Address contains an unclosed quoted string.",
+        "UNCLOSEDCOMMENT": "Address contains an unclosed comment.",
+        "UNCLOSEDDOMLIT": (
+            "Address contains a domain literal " "that is missing its closing bracket."
+        ),
+        "FWS_CRLF_X2": (
+            "Address contains a Folding White Space "
+            "that has consecutive CRLF sequences."
+        ),
+        "FWS_CRLF_END": (
+            "Address contains a Folding White Space " "that ends with a CRLF sequence."
+        ),
+        "CR_NO_LF": (
+            "Address contains a carriage return "
+            "that is not followed by a line return."
+        ),
+        "BAD_PARSE": "Address is malformed.",
     }
 
     REFERENCES = {
-        'EXPECTING_DTEXT': ['dtext'],
-        'NOLOCALPART': ['local-part'],
-        'NODOMAIN': ['addr-spec', 'mailbox'],
-        'CONSECUTIVEDOTS': ['local-part', 'domain-RFC5322', 'domain-RFC5321'],
-        'ATEXT_AFTER_CFWS': ['local-part', 'domain-RFC5322'],
-        'ATEXT_AFTER_QS': ['local-part'],
-        'ATEXT_AFTER_DOMLIT': ['domain-RFC5322'],
-        'EXPECTING_QPAIR': ['quoted-pair'],
-        'EXPECTING_ATEXT': ['atext'],
-        'EXPECTING_QTEXT': ['qtext'],
-        'EXPECTING_CTEXT': ['ctext'],
-        'BACKSLASHEND': ['domain-RFC5322', 'domain-RFC5321', 'quoted-pair'],
-        'DOT_START': ['local-part', 'domain-RFC5322', 'domain-RFC5321'],
-        'DOT_END': ['local-part', 'domain-RFC5322', 'domain-RFC5321'],
-        'DOMAINHYPHENSTART': ['sub-domain'],
-        'DOMAINHYPHENEND': ['sub-domain'],
-        'UNCLOSEDQUOTEDSTR': ['quoted-string'],
-        'UNCLOSEDCOMMENT': ['CFWS'],
-        'UNCLOSEDDOMLIT': ['domain-literal'],
-        'FWS_CRLF_X2': ['CFWS'],
-        'FWS_CRLF_END': ['CFWS'],
-        'CR_NO_LF': ['CFWS', 'CRLF'],
-        'BAD_PARSE': [],
+        "EXPECTING_DTEXT": ["dtext"],
+        "NOLOCALPART": ["local-part"],
+        "NODOMAIN": ["addr-spec", "mailbox"],
+        "CONSECUTIVEDOTS": ["local-part", "domain-RFC5322", "domain-RFC5321"],
+        "ATEXT_AFTER_CFWS": ["local-part", "domain-RFC5322"],
+        "ATEXT_AFTER_QS": ["local-part"],
+        "ATEXT_AFTER_DOMLIT": ["domain-RFC5322"],
+        "EXPECTING_QPAIR": ["quoted-pair"],
+        "EXPECTING_ATEXT": ["atext"],
+        "EXPECTING_QTEXT": ["qtext"],
+        "EXPECTING_CTEXT": ["ctext"],
+        "BACKSLASHEND": ["domain-RFC5322", "domain-RFC5321", "quoted-pair"],
+        "DOT_START": ["local-part", "domain-RFC5322", "domain-RFC5321"],
+        "DOT_END": ["local-part", "domain-RFC5322", "domain-RFC5321"],
+        "DOMAINHYPHENSTART": ["sub-domain"],
+        "DOMAINHYPHENEND": ["sub-domain"],
+        "UNCLOSEDQUOTEDSTR": ["quoted-string"],
+        "UNCLOSEDCOMMENT": ["CFWS"],
+        "UNCLOSEDDOMLIT": ["domain-literal"],
+        "FWS_CRLF_X2": ["CFWS"],
+        "FWS_CRLF_END": ["CFWS"],
+        "CR_NO_LF": ["CFWS", "CRLF"],
+        "BAD_PARSE": [],
     }

--- a/pyisemail/diagnosis/rfc5321_diagnosis.py
+++ b/pyisemail/diagnosis/rfc5321_diagnosis.py
@@ -3,35 +3,36 @@ from pyisemail.diagnosis import BaseDiagnosis
 
 class RFC5321Diagnosis(BaseDiagnosis):
 
-    """A diagnosis indicating the address is only valid for SMTP.
-
-    """
+    """A diagnosis indicating the address is only valid for SMTP."""
 
     DESCRIPTION = "Address is valid for SMTP but has unusual elements."
 
     ERROR_CODES = {
-        'TLD': 9,
-        'TLDNUMERIC': 10,
-        'QUOTEDSTRING': 11,
-        'ADDRESSLITERAL': 12,
-        'IPV6DEPRECATED': 13,
+        "TLD": 9,
+        "TLDNUMERIC": 10,
+        "QUOTEDSTRING": 11,
+        "ADDRESSLITERAL": 12,
+        "IPV6DEPRECATED": 13,
     }
 
     MESSAGES = {
-        'TLD': "Address is valid but at a Top Level Domain.",
-        'TLDNUMERIC': ("Address is valid but the Top Level Domain "
-                       "begins with a number."),
-        'QUOTEDSTRING': "Address is valid but contains a quoted string.",
-        'ADDRESSLITERAL': ("Address is valid but at a literal address, "
-                           "not a domain."),
-        'IPV6DEPRECATED': ("Address is valid but contains a :: that "
-                           "only elides one zero group."),
+        "TLD": "Address is valid but at a Top Level Domain.",
+        "TLDNUMERIC": (
+            "Address is valid but the Top Level Domain " "begins with a number."
+        ),
+        "QUOTEDSTRING": "Address is valid but contains a quoted string.",
+        "ADDRESSLITERAL": (
+            "Address is valid but at a literal address, " "not a domain."
+        ),
+        "IPV6DEPRECATED": (
+            "Address is valid but contains a :: that " "only elides one zero group."
+        ),
     }
 
     REFERENCES = {
-        'TLD': ['TLD'],
-        'TLDNUMERIC': ['TLD-format'],
-        'QUOTEDSTRING': ['quoted-string'],
-        'ADDRESSLITERAL': ['address-literal', 'address-literal-IPv4'],
-        'IPV6DEPRECATED': ['address-literal-IPv6'],
+        "TLD": ["TLD"],
+        "TLDNUMERIC": ["TLD-format"],
+        "QUOTEDSTRING": ["quoted-string"],
+        "ADDRESSLITERAL": ["address-literal", "address-literal-IPv4"],
+        "IPV6DEPRECATED": ["address-literal-IPv6"],
     }

--- a/pyisemail/diagnosis/rfc5322_diagnosis.py
+++ b/pyisemail/diagnosis/rfc5322_diagnosis.py
@@ -3,68 +3,84 @@ from pyisemail.diagnosis import BaseDiagnosis
 
 class RFC5322Diagnosis(BaseDiagnosis):
 
-    """A diagnosis indicating the address is only technically valid.
+    """A diagnosis indicating the address is only technically valid."""
 
-    """
-
-    DESCRIPTION = ("Address is only valid according to the "
-                   "broad definition of RFC5322. It is otherwise invalid.")
+    DESCRIPTION = (
+        "Address is only valid according to the "
+        "broad definition of RFC5322. It is otherwise invalid."
+    )
 
     ERROR_CODES = {
-        'DOMAIN': 65,
-        'TOOLONG': 66,
-        'LOCAL_TOOLONG': 67,
-        'DOMAIN_TOOLONG': 68,
-        'LABEL_TOOLONG': 69,
-        'DOMAINLITERAL': 70,
-        'DOMLIT_OBSDTEXT': 71,
-        'IPV6_GRPCOUNT': 72,
-        'IPV6_2X2XCOLON': 73,
-        'IPV6_BADCHAR': 74,
-        'IPV6_MAXGRPS': 75,
-        'IPV6_COLONSTRT': 76,
-        'IPV6_COLONEND': 77,
+        "DOMAIN": 65,
+        "TOOLONG": 66,
+        "LOCAL_TOOLONG": 67,
+        "DOMAIN_TOOLONG": 68,
+        "LABEL_TOOLONG": 69,
+        "DOMAINLITERAL": 70,
+        "DOMLIT_OBSDTEXT": 71,
+        "IPV6_GRPCOUNT": 72,
+        "IPV6_2X2XCOLON": 73,
+        "IPV6_BADCHAR": 74,
+        "IPV6_MAXGRPS": 75,
+        "IPV6_COLONSTRT": 76,
+        "IPV6_COLONEND": 77,
     }
 
     MESSAGES = {
-        'DOMAIN': ("Address is RFC5322 compliant but contains domain "
-                   "characters that are not allowed by DNS."),
-        'TOOLONG': "Address is too long.",
-        'LOCAL_TOOLONG': "Address contains a local part that is too long.",
-        'DOMAIN_TOOLONG': "Address contains a domain that is too long.",
-        'LABEL_TOOLONG': ("Address contains a domain part with an element "
-                          "that is too long."),
-        'DOMAINLITERAL': ("Address contains a domain literal that is "
-                          "not a valid RFC5321 address literal."),
-        'DOMLIT_OBSDTEXT': ("Address contains a domain literal that is "
-                            "not a valid RFC5321 address literal and "
-                            "contains obsolete characters."),
-        'IPV6_GRPCOUNT': ("Address contains an IPv6 literal address with "
-                          "the wrong number of groups."),
-        'IPV6_2X2XCOLON': ("Address contains an IPv6 literal address with "
-                           "too many :: sequences."),
-        'IPV6_BADCHAR': ("Address contains an IPv6 literal address with "
-                         "an illegal group of characters."),
-        'IPV6_MAXGRPS': ("Address contains an IPv6 literal address with "
-                         "too many groups."),
-        'IPV6_COLONSTRT': ("Address contains an IPv6 literal address that "
-                           "starts with a single colon."),
-        'IPV6_COLONEND': ("Address contains an IPv6 literal address that "
-                          "ends with a single colon."),
+        "DOMAIN": (
+            "Address is RFC5322 compliant but contains domain "
+            "characters that are not allowed by DNS."
+        ),
+        "TOOLONG": "Address is too long.",
+        "LOCAL_TOOLONG": "Address contains a local part that is too long.",
+        "DOMAIN_TOOLONG": "Address contains a domain that is too long.",
+        "LABEL_TOOLONG": (
+            "Address contains a domain part with an element " "that is too long."
+        ),
+        "DOMAINLITERAL": (
+            "Address contains a domain literal that is "
+            "not a valid RFC5321 address literal."
+        ),
+        "DOMLIT_OBSDTEXT": (
+            "Address contains a domain literal that is "
+            "not a valid RFC5321 address literal and "
+            "contains obsolete characters."
+        ),
+        "IPV6_GRPCOUNT": (
+            "Address contains an IPv6 literal address with "
+            "the wrong number of groups."
+        ),
+        "IPV6_2X2XCOLON": (
+            "Address contains an IPv6 literal address with " "too many :: sequences."
+        ),
+        "IPV6_BADCHAR": (
+            "Address contains an IPv6 literal address with "
+            "an illegal group of characters."
+        ),
+        "IPV6_MAXGRPS": (
+            "Address contains an IPv6 literal address with " "too many groups."
+        ),
+        "IPV6_COLONSTRT": (
+            "Address contains an IPv6 literal address that "
+            "starts with a single colon."
+        ),
+        "IPV6_COLONEND": (
+            "Address contains an IPv6 literal address that " "ends with a single colon."
+        ),
     }
 
     REFERENCES = {
-        'DOMAIN': ['domain-RFC5322'],
-        'TOOLONG': ['mailbox-maximum'],
-        'LOCAL_TOOLONG': ['local-part-maximum'],
-        'DOMAIN_TOOLONG': ['domain-maximum'],
-        'LABEL_TOOLONG': ['label'],
-        'DOMAINLITERAL': ['domain-literal'],
-        'DOMLIT_OBSDTEXT': ['obs-dtext'],
-        'IPV6_GRPCOUNT': ['address-literal-IPv6'],
-        'IPV6_2X2XCOLON': ['address-literal-IPv6'],
-        'IPV6_BADCHAR': ['address-literal-IPv6'],
-        'IPV6_MAXGRPS': ['address-literal-IPv6'],
-        'IPV6_COLONSTRT': ['address-literal-IPv6'],
-        'IPV6_COLONEND': ['address-literal-IPv6'],
+        "DOMAIN": ["domain-RFC5322"],
+        "TOOLONG": ["mailbox-maximum"],
+        "LOCAL_TOOLONG": ["local-part-maximum"],
+        "DOMAIN_TOOLONG": ["domain-maximum"],
+        "LABEL_TOOLONG": ["label"],
+        "DOMAINLITERAL": ["domain-literal"],
+        "DOMLIT_OBSDTEXT": ["obs-dtext"],
+        "IPV6_GRPCOUNT": ["address-literal-IPv6"],
+        "IPV6_2X2XCOLON": ["address-literal-IPv6"],
+        "IPV6_BADCHAR": ["address-literal-IPv6"],
+        "IPV6_MAXGRPS": ["address-literal-IPv6"],
+        "IPV6_COLONSTRT": ["address-literal-IPv6"],
+        "IPV6_COLONEND": ["address-literal-IPv6"],
     }

--- a/pyisemail/diagnosis/valid_diagnosis.py
+++ b/pyisemail/diagnosis/valid_diagnosis.py
@@ -3,18 +3,18 @@ from pyisemail.diagnosis import BaseDiagnosis
 
 class ValidDiagnosis(BaseDiagnosis):
 
-    """A diagnosis indicating the address is valid for use.
-
-    """
+    """A diagnosis indicating the address is valid for use."""
 
     DESCRIPTION = "Address is valid."
 
-    MESSAGE = ("Address is valid. Please note that this does not mean "
-               "the address actually exists, nor even that the domain "
-               "actually exists. This address could be issued by the "
-               "domain owner without breaking the rules of any RFCs.")
+    MESSAGE = (
+        "Address is valid. Please note that this does not mean "
+        "the address actually exists, nor even that the domain "
+        "actually exists. This address could be issued by the "
+        "domain owner without breaking the rules of any RFCs."
+    )
 
-    def __init__(self, diagnosis_type='VALID'):
+    def __init__(self, diagnosis_type="VALID"):
         self.diagnosis_type = diagnosis_type
         self.description = self.DESCRIPTION
         self.message = self.MESSAGE

--- a/pyisemail/reference.py
+++ b/pyisemail/reference.py
@@ -8,140 +8,140 @@ class Reference(object):
     """
 
     DATA = {
-        'local-part': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC5322 section 3.4.1",
+        "local-part": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC5322 section 3.4.1",
         },
-        'local-part-maximum': {
-            'link': "http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1",
-            'citation': "RFC5321 section 4.5.3.1.1",
+        "local-part-maximum": {
+            "link": "http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1",
+            "citation": "RFC5321 section 4.5.3.1.1",
         },
-        'obs-local-part': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC 5322 section 3.4.1",
+        "obs-local-part": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC 5322 section 3.4.1",
         },
-        'dot-atom': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC 5322 section 3.4.1",
+        "dot-atom": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC 5322 section 3.4.1",
         },
-        'quoted-string': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC 5322 section 3.4.1",
+        "quoted-string": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC 5322 section 3.4.1",
         },
-        'CFWS-near-at': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC 5322 section 3.4.1",
+        "CFWS-near-at": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC 5322 section 3.4.1",
         },
-        'SHOULD-NOT': {
-            'link': "http://tools.ietf.org/html/rfc2119",
-            'citation': "RFC2119 section 4",
+        "SHOULD-NOT": {
+            "link": "http://tools.ietf.org/html/rfc2119",
+            "citation": "RFC2119 section 4",
         },
-        'atext': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.2.3",
-            'citation': "RFC5322 section 3.2.3",
+        "atext": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.2.3",
+            "citation": "RFC5322 section 3.2.3",
         },
-        'obs-domain': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC5322 section 3.4.1",
+        "obs-domain": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC5322 section 3.4.1",
         },
-        'domain-RFC5322': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC5322 section 3.4.1",
+        "domain-RFC5322": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC5322 section 3.4.1",
         },
-        'domain-RFC5321': {
-            'link': "http://tools.ietf.org/html/rfc5321#section-4.1.2",
-            'citation': "RFC5321 section 4.1.2",
+        "domain-RFC5321": {
+            "link": "http://tools.ietf.org/html/rfc5321#section-4.1.2",
+            "citation": "RFC5321 section 4.1.2",
         },
-        'label': {
-            'link': "http://tools.ietf.org/html/rfc1035#section-2.3.4",
-            'citation': "RFC1035 section 2.3.4",
+        "label": {
+            "link": "http://tools.ietf.org/html/rfc1035#section-2.3.4",
+            "citation": "RFC1035 section 2.3.4",
         },
-        'CRLF': {
-            'link': "http://tools.ietf.org/html/rfc5234#section-2.3",
-            'citation': "RFC5234 section 2.3",
+        "CRLF": {
+            "link": "http://tools.ietf.org/html/rfc5234#section-2.3",
+            "citation": "RFC5234 section 2.3",
         },
-        'CFWS': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.2.2",
-            'citation': "RFC5322 section 3.2.2",
+        "CFWS": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.2.2",
+            "citation": "RFC5322 section 3.2.2",
         },
-        'domain-literal': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC5322 section 3.4.1",
+        "domain-literal": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC5322 section 3.4.1",
         },
-        'address-literal': {
-            'link': "http://tools.ietf.org/html/rfc5321#section-4.1.2",
-            'citation': "RFC5321 section 4.1.2",
+        "address-literal": {
+            "link": "http://tools.ietf.org/html/rfc5321#section-4.1.2",
+            "citation": "RFC5321 section 4.1.2",
         },
-        'address-literal-IPv4': {
-            'link': "http://tools.ietf.org/html/rfc5321#section-4.1.3",
-            'citation': "RFC5321 section 4.1.3",
+        "address-literal-IPv4": {
+            "link": "http://tools.ietf.org/html/rfc5321#section-4.1.3",
+            "citation": "RFC5321 section 4.1.3",
         },
-        'address-literal-IPv6': {
-            'link': "http://tools.ietf.org/html/rfc5321#section-4.1.3",
-            'citation': "RFC5321 section 4.1.3",
+        "address-literal-IPv6": {
+            "link": "http://tools.ietf.org/html/rfc5321#section-4.1.3",
+            "citation": "RFC5321 section 4.1.3",
         },
-        'dtext': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC5322 section 3.4.1",
+        "dtext": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC5322 section 3.4.1",
         },
-        'obs-dtext': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC5322 section 3.4.1",
+        "obs-dtext": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC5322 section 3.4.1",
         },
-        'qtext': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.2.4",
-            'citation': "RFC5322 section 3.2.4",
+        "qtext": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.2.4",
+            "citation": "RFC5322 section 3.2.4",
         },
-        'obs-qtext': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-4.1",
-            'citation': "RFC5322 section 4.1",
+        "obs-qtext": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-4.1",
+            "citation": "RFC5322 section 4.1",
         },
-        'ctext': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.2.3",
-            'citation': "RFC5322 section 3.2.3",
+        "ctext": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.2.3",
+            "citation": "RFC5322 section 3.2.3",
         },
-        'obs-ctext': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-4.1",
-            'citation': "RFC5322 section 4.1",
+        "obs-ctext": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-4.1",
+            "citation": "RFC5322 section 4.1",
         },
-        'quoted-pair': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.2.1",
-            'citation': "RFC5322 section 3.2.1",
+        "quoted-pair": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.2.1",
+            "citation": "RFC5322 section 3.2.1",
         },
-        'obs-qp': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-4.1",
-            'citation': "RFC5322 section 4.1",
+        "obs-qp": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-4.1",
+            "citation": "RFC5322 section 4.1",
         },
-        'TLD': {
-            'link': "http://tools.ietf.org/html/rfc5321#section-2.3.5",
-            'citation': "RFC5321 section 2.3.5",
+        "TLD": {
+            "link": "http://tools.ietf.org/html/rfc5321#section-2.3.5",
+            "citation": "RFC5321 section 2.3.5",
         },
-        'TLD-format': {
-            'link': "http://www.rfc-editor.org/errata_search.php?eid=1353",
-            'citation': "John Klensin, RFC 1123 erratum 1353",
+        "TLD-format": {
+            "link": "http://www.rfc-editor.org/errata_search.php?eid=1353",
+            "citation": "John Klensin, RFC 1123 erratum 1353",
         },
-        'mailbox-maximum': {
-            'link': "http://www.rfc-editor.org/errata_search.php?eid=1690",
-            'citation': "Dominic Sayers, RFC 3696 erratum 1690",
+        "mailbox-maximum": {
+            "link": "http://www.rfc-editor.org/errata_search.php?eid=1690",
+            "citation": "Dominic Sayers, RFC 3696 erratum 1690",
         },
-        'domain-maximum': {
-            'link': "http://tools.ietf.org/html/rfc1035#section-4.5.3.1.2",
-            'citation': "RFC 5321 section 4.5.3.1.2",
+        "domain-maximum": {
+            "link": "http://tools.ietf.org/html/rfc1035#section-4.5.3.1.2",
+            "citation": "RFC 5321 section 4.5.3.1.2",
         },
-        'mailbox': {
-            'link': "http://tools.ietf.org/html/rfc5321#section-4.1.2",
-            'citation': "RFC 5321 section 4.1.2",
+        "mailbox": {
+            "link": "http://tools.ietf.org/html/rfc5321#section-4.1.2",
+            "citation": "RFC 5321 section 4.1.2",
         },
-        'addr-spec': {
-            'link': "http://tools.ietf.org/html/rfc5322#section-3.4.1",
-            'citation': "RFC 5322 section 3.4.1",
+        "addr-spec": {
+            "link": "http://tools.ietf.org/html/rfc5322#section-3.4.1",
+            "citation": "RFC 5322 section 3.4.1",
         },
     }
 
     def __init__(self, name=""):
-        data = self.DATA.get(name, {'link': "", 'citation': ""})
-        self.link = data['link']
-        self.citation = data['citation']
+        data = self.DATA.get(name, {"link": "", "citation": ""})
+        self.link = data["link"]
+        self.citation = data["citation"]
 
     def __repr__(self):
         return "%s (%r)" % (self.__class__, self.__dict__)

--- a/pyisemail/utils.py
+++ b/pyisemail/utils.py
@@ -7,4 +7,4 @@ def enum(**enums):
 
     """
 
-    return type('Enum', (), enums)
+    return type("Enum", (), enums)

--- a/pyisemail/validators/__init__.py
+++ b/pyisemail/validators/__init__.py
@@ -2,4 +2,4 @@ from pyisemail.validators.dns_validator import DNSValidator
 from pyisemail.validators.gtld_validator import GTLDValidator
 from pyisemail.validators.parser_validator import ParserValidator
 
-__all__ = ['DNSValidator', 'GTLDValidator', 'ParserValidator']
+__all__ = ["DNSValidator", "GTLDValidator", "ParserValidator"]

--- a/pyisemail/validators/dns_validator.py
+++ b/pyisemail/validators/dns_validator.py
@@ -4,7 +4,6 @@ from pyisemail.diagnosis import DNSDiagnosis, RFC5321Diagnosis, ValidDiagnosis
 
 
 class DNSValidator(object):
-
     def is_valid(self, domain, diagnose=False):
 
         """Check whether a domain has a valid MX or A record.
@@ -37,31 +36,31 @@ class DNSValidator(object):
         # we will raise a warning because we didn't immediately find an MX
         # record.
         try:
-            dns.resolver.query(domain, 'MX')
+            dns.resolver.query(domain, "MX")
             dns_checked = True
         except (dns.resolver.NXDOMAIN, dns.name.NameTooLong):
             # Domain can't be found in DNS
-            return_status.append(DNSDiagnosis('NO_RECORD'))
+            return_status.append(DNSDiagnosis("NO_RECORD"))
 
             # Since dns.resolver gives more information than the PHP analog, we
             # can say that TLDs that throw an NXDOMAIN or NameTooLong error
             # have been checked
-            if len(domain.split('.')) == 1:
+            if len(domain.split(".")) == 1:
                 dns_checked = True
         except dns.resolver.NoAnswer:
             # MX-record for domain can't be found
-            return_status.append(DNSDiagnosis('NO_MX_RECORD'))
+            return_status.append(DNSDiagnosis("NO_MX_RECORD"))
 
             try:
                 # TODO: See if we can/need to narrow to A / CNAME
                 dns.resolver.query(domain)
             except dns.resolver.NoAnswer:
                 # No usable records for the domain can be found
-                return_status.append(DNSDiagnosis('NO_RECORD'))
+                return_status.append(DNSDiagnosis("NO_RECORD"))
         except dns.resolver.NoNameservers:
-            return_status.append(DNSDiagnosis('NO_NAMESERVERS'))
+            return_status.append(DNSDiagnosis("NO_NAMESERVERS"))
         except (dns.exception.Timeout, dns.resolver.Timeout):
-            return_status.append(DNSDiagnosis('DNS_TIMEDOUT'))
+            return_status.append(DNSDiagnosis("DNS_TIMEDOUT"))
 
         # Check for TLD addresses
         # -----------------------
@@ -98,11 +97,11 @@ class DNSValidator(object):
         if not dns_checked:
             atom_list = domain.split(".")
             if len(atom_list) == 1:
-                return_status.append(RFC5321Diagnosis('TLD'))
+                return_status.append(RFC5321Diagnosis("TLD"))
 
             try:
-                float(atom_list[len(atom_list)-1][0])
-                return_status.append(RFC5321Diagnosis('TLDNUMERIC'))
+                float(atom_list[len(atom_list) - 1][0])
+                return_status.append(RFC5321Diagnosis("TLDNUMERIC"))
             except ValueError:
                 pass
 

--- a/pyisemail/validators/parser_validator.py
+++ b/pyisemail/validators/parser_validator.py
@@ -9,33 +9,31 @@ from pyisemail.utils import enum
 
 __all__ = ["ParserValidator"]
 
-Char = enum(AT='@',
-            BACKSLASH='\\',
-            DOT='.',
-            DQUOTE='"',
-            OPENPARENTHESIS='(',
-            CLOSEPARENTHESIS=')',
-            OPENSQBRACKET='[',
-            CLOSESQBRACKET=']',
-            HYPHEN='-',
-            COLON=':',
-            DOUBLECOLON='::',
-            SP=' ',
-            HTAB="\t",
-            CR="\r",
-            LF="\n",
-            IPV6TAG='IPv6:',
-            # US-ASCII visible characters not valid for atext
-            # (http:#tools.ietf.org/html/rfc5322#section-3.2.3)
-            SPECIALS='()<>[]:;@\\,."')
+Char = enum(
+    AT="@",
+    BACKSLASH="\\",
+    DOT=".",
+    DQUOTE='"',
+    OPENPARENTHESIS="(",
+    CLOSEPARENTHESIS=")",
+    OPENSQBRACKET="[",
+    CLOSESQBRACKET="]",
+    HYPHEN="-",
+    COLON=":",
+    DOUBLECOLON="::",
+    SP=" ",
+    HTAB="\t",
+    CR="\r",
+    LF="\n",
+    IPV6TAG="IPv6:",
+    # US-ASCII visible characters not valid for atext
+    # (http:#tools.ietf.org/html/rfc5322#section-3.2.3)
+    SPECIALS='()<>[]:;@\\,."',
+)
 
-Context = enum(LOCALPART=0,
-               DOMAIN=1,
-               LITERAL=2,
-               COMMENT=3,
-               FWS=4,
-               QUOTEDSTRING=5,
-               QUOTEDPAIR=6)
+Context = enum(
+    LOCALPART=0, DOMAIN=1, LITERAL=2, COMMENT=3, FWS=4, QUOTEDSTRING=5, QUOTEDPAIR=6
+)
 
 if sys.version_info[0] == 3:
     _unichr = chr
@@ -78,29 +76,29 @@ class ParserValidator(EmailValidator):
 
         """
 
-        threshold = BaseDiagnosis.CATEGORIES['VALID']
+        threshold = BaseDiagnosis.CATEGORIES["VALID"]
         return_status = [ValidDiagnosis()]
         parse_data = {}
 
         # Parse the address into components, character by character
         raw_length = len(address)
-        context = Context.LOCALPART              # Where we are
-        context_stack = [context]                # Where we've been
-        context_prior = Context.LOCALPART        # Where we just came from
-        token = ''                               # The current character
-        token_prior = ''                         # The previous character
-        parse_data[Context.LOCALPART] = ''       # The address' components
-        parse_data[Context.DOMAIN] = ''
+        context = Context.LOCALPART  # Where we are
+        context_stack = [context]  # Where we've been
+        context_prior = Context.LOCALPART  # Where we just came from
+        token = ""  # The current character
+        token_prior = ""  # The previous character
+        parse_data[Context.LOCALPART] = ""  # The address' components
+        parse_data[Context.DOMAIN] = ""
         atom_list = {
-            Context.LOCALPART: [''],
-            Context.DOMAIN: ['']
-        }                                        # The address' dot-atoms
+            Context.LOCALPART: [""],
+            Context.DOMAIN: [""],
+        }  # The address' dot-atoms
         element_count = 0
         element_len = 0
-        hyphen_flag = False     # Hyphen cannot occur at the end of a subdomain
-        end_or_die = False      # CFWS can only appear at the end of an element
-        skip = False            # Skip flag that simulates i++
-        crlf_count = -1         # crlf_count = -1 == !isset(crlf_count)
+        hyphen_flag = False  # Hyphen cannot occur at the end of a subdomain
+        end_or_die = False  # CFWS can only appear at the end of an element
+        skip = False  # Skip flag that simulates i++
+        crlf_count = -1  # crlf_count = -1 == !isset(crlf_count)
 
         for i in _range(raw_length):
 
@@ -143,12 +141,11 @@ class ParserValidator(EmailValidator):
                         if element_len == 0:
                             # Comments are OK at the beginning of an element
                             if element_count == 0:
-                                return_status.append(CFWSDiagnosis('COMMENT'))
+                                return_status.append(CFWSDiagnosis("COMMENT"))
                             else:
-                                return_status.append(
-                                    DeprecatedDiagnosis('COMMENT'))
+                                return_status.append(DeprecatedDiagnosis("COMMENT"))
                         else:
-                            return_status.append(CFWSDiagnosis('COMMENT'))
+                            return_status.append(CFWSDiagnosis("COMMENT"))
                             # We can't start a comment in the middle of an
                             # element, so this better be the end
                             end_or_die = True
@@ -159,18 +156,17 @@ class ParserValidator(EmailValidator):
                         if element_len == 0:
                             # Another dot, already? Fatal error
                             if element_count == 0:
-                                return_status.append(
-                                    InvalidDiagnosis('DOT_START'))
+                                return_status.append(InvalidDiagnosis("DOT_START"))
                             else:
                                 return_status.append(
-                                    InvalidDiagnosis('CONSECUTIVEDOTS'))
+                                    InvalidDiagnosis("CONSECUTIVEDOTS")
+                                )
                         else:
                             # The entire local-part can be a quoted string for
                             # RFC 5321. If it's just one atom that is quoted
                             # then it's an RFC 5322 obsolete form
                             if end_or_die:
-                                return_status.append(
-                                    DeprecatedDiagnosis('LOCALPART'))
+                                return_status.append(DeprecatedDiagnosis("LOCALPART"))
 
                             # CFWS & quoted strings are OK again now we're at
                             # the beginning of an element (although they are
@@ -179,18 +175,16 @@ class ParserValidator(EmailValidator):
                             element_len = 0
                             element_count += 1
                             parse_data[Context.LOCALPART] += token
-                            atom_list[Context.LOCALPART].append('')
+                            atom_list[Context.LOCALPART].append("")
                     elif token == Char.DQUOTE:
                         if element_len == 0:
                             # The entire local-part can be a quoted string for
                             # RFC 5321. If it's just one atom that is quoted
                             # then it's an RFC 5322 obsolete form
                             if element_count == 0:
-                                return_status.append(
-                                    RFC5321Diagnosis('QUOTEDSTRING'))
+                                return_status.append(RFC5321Diagnosis("QUOTEDSTRING"))
                             else:
-                                return_status.append(
-                                    DeprecatedDiagnosis('LOCALPART'))
+                                return_status.append(DeprecatedDiagnosis("LOCALPART"))
 
                             parse_data[Context.LOCALPART] += token
                             atom_list[Context.LOCALPART][element_count] += token
@@ -200,8 +194,7 @@ class ParserValidator(EmailValidator):
                             context = Context.QUOTEDSTRING
                         else:
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('EXPECTING_ATEXT'))
+                            return_status.append(InvalidDiagnosis("EXPECTING_ATEXT"))
                     # Folding White Space (FWS)
                     elif token in [Char.CR, Char.SP, Char.HTAB]:
                         # Skip simulates the use of ++ operator if the latter
@@ -209,18 +202,18 @@ class ParserValidator(EmailValidator):
                         if token == Char.CR:
                             skip = True
 
-                            if (i+1 == raw_length or
-                                    to_char(address[i+1]) != Char.LF):
-                                return_status.append(
-                                    InvalidDiagnosis('CR_NO_LF'))
+                            if (
+                                i + 1 == raw_length
+                                or to_char(address[i + 1]) != Char.LF
+                            ):
+                                return_status.append(InvalidDiagnosis("CR_NO_LF"))
                                 break
 
                         if element_len == 0:
                             if element_count == 0:
-                                return_status.append(CFWSDiagnosis('FWS'))
+                                return_status.append(CFWSDiagnosis("FWS"))
                             else:
-                                return_status.append(
-                                    DeprecatedDiagnosis('FWS'))
+                                return_status.append(DeprecatedDiagnosis("FWS"))
                         else:
                             # We can't start FWS in the middle of an element,
                             # so this better be the end
@@ -234,23 +227,21 @@ class ParserValidator(EmailValidator):
                         # At this point we should have a valid local-part
                         if len(context_stack) != 1:  # pragma: no cover
                             if diagnose:
-                                return InvalidDiagnosis('BAD_PARSE')
+                                return InvalidDiagnosis("BAD_PARSE")
                             else:
                                 return False
 
-                        if parse_data[Context.LOCALPART] == '':
+                        if parse_data[Context.LOCALPART] == "":
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('NOLOCALPART'))
+                            return_status.append(InvalidDiagnosis("NOLOCALPART"))
                         elif element_len == 0:
                             # Fatal error
-                            return_status.append(InvalidDiagnosis('DOT_END'))
+                            return_status.append(InvalidDiagnosis("DOT_END"))
                         # http://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
                         #   The maximum total length of a user name or other
                         #   local-part is 64 octets.
                         elif len(parse_data[Context.LOCALPART]) > 64:
-                            return_status.append(
-                                RFC5322Diagnosis('LOCAL_TOOLONG'))
+                            return_status.append(RFC5322Diagnosis("LOCAL_TOOLONG"))
                         # http://tools.ietf.org/html/rfc5322#section-3.4.1
                         #   Comments and folding white space
                         #   SHOULD NOT be used around the "@" in the addr-spec.
@@ -264,8 +255,7 @@ class ParserValidator(EmailValidator):
                         #    the case carefully weighed before implementing any
                         #    behavior described with this label.
                         elif context_prior in [Context.COMMENT, Context.FWS]:
-                            return_status.append(
-                                DeprecatedDiagnosis('CFWS_NEAR_AT'))
+                            return_status.append(DeprecatedDiagnosis("CFWS_NEAR_AT"))
 
                         # Clear everything down for the domain parsing
                         context = Context.DOMAIN
@@ -293,23 +283,23 @@ class ParserValidator(EmailValidator):
                             # valid
                             if context_prior in [Context.COMMENT, Context.FWS]:
                                 return_status.append(
-                                    InvalidDiagnosis('ATEXT_AFTER_CFWS'))
+                                    InvalidDiagnosis("ATEXT_AFTER_CFWS")
+                                )
                             elif context_prior == Context.QUOTEDSTRING:
-                                return_status.append(
-                                    InvalidDiagnosis('ATEXT_AFTER_QS'))
+                                return_status.append(InvalidDiagnosis("ATEXT_AFTER_QS"))
                             else:  # pragma: no cover
                                 if diagnose:
-                                    return InvalidDiagnosis('BAD_PARSE')
+                                    return InvalidDiagnosis("BAD_PARSE")
                                 else:
                                     return False
                         else:
                             context_prior = context
                             o = ord(token)
 
-                            if (o < 33 or o > 126 or o == 10 or
-                                    token in Char.SPECIALS):
+                            if o < 33 or o > 126 or o == 10 or token in Char.SPECIALS:
                                 return_status.append(
-                                    InvalidDiagnosis('EXPECTING_ATEXT'))
+                                    InvalidDiagnosis("EXPECTING_ATEXT")
+                                )
 
                             parse_data[Context.LOCALPART] += token
                             atom_list[Context.LOCALPART][element_count] += token
@@ -375,12 +365,12 @@ class ParserValidator(EmailValidator):
                             # (http://tools.ietf.org/html/rfc5322#section-3.4.1)
                             if element_count == 0:
                                 return_status.append(
-                                    DeprecatedDiagnosis('CFWS_NEAR_AT'))
+                                    DeprecatedDiagnosis("CFWS_NEAR_AT")
+                                )
                             else:
-                                return_status.append(
-                                    DeprecatedDiagnosis('COMMENT'))
+                                return_status.append(DeprecatedDiagnosis("COMMENT"))
                         else:
-                            return_status.append(CFWSDiagnosis('COMMENT'))
+                            return_status.append(CFWSDiagnosis("COMMENT"))
                             # We can't start a comment in the middle of an
                             # element, so this better be the end
                             end_or_die = True
@@ -392,15 +382,14 @@ class ParserValidator(EmailValidator):
                         if element_len == 0:
                             # Another dot, already? Fatal error
                             if element_count == 0:
-                                return_status.append(
-                                    InvalidDiagnosis('DOT_START'))
+                                return_status.append(InvalidDiagnosis("DOT_START"))
                             else:
                                 return_status.append(
-                                    InvalidDiagnosis('CONSECUTIVEDOTS'))
+                                    InvalidDiagnosis("CONSECUTIVEDOTS")
+                                )
                         elif hyphen_flag:
                             # Previous subdomain ended in a hyphen. Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('DOMAINHYPHENEND'))
+                            return_status.append(InvalidDiagnosis("DOMAINHYPHENEND"))
                         else:
                             # Nowhere in RFC 5321 does it say explicitly that
                             # the domain part of a Mailbox must be a valid
@@ -417,19 +406,18 @@ class ParserValidator(EmailValidator):
                             # http://tools.ietf.org/html/rfc1035#section-2.3.4
                             # labels         63 octets or less
                             if element_len > 63:
-                                return_status.append(
-                                    RFC5322Diagnosis('LABEL_TOOLONG'))
+                                return_status.append(RFC5322Diagnosis("LABEL_TOOLONG"))
 
                             # CFWS is OK again now we're at the beginning of an
                             # element (although it may be obsolete CFWS)
                             end_or_die = False
                             element_len = 0
                             element_count += 1
-                            atom_list[Context.DOMAIN].append('')
+                            atom_list[Context.DOMAIN].append("")
                             parse_data[Context.DOMAIN] += token
                     # Domain literal
                     elif token == Char.OPENSQBRACKET:
-                        if parse_data[Context.DOMAIN] == '':
+                        if parse_data[Context.DOMAIN] == "":
                             # Domain literal must be the only component
                             end_or_die = True
                             element_len += 1
@@ -437,11 +425,10 @@ class ParserValidator(EmailValidator):
                             context = Context.LITERAL
                             parse_data[Context.DOMAIN] += token
                             atom_list[Context.DOMAIN][element_count] += token
-                            parse_data['literal'] = ''
+                            parse_data["literal"] = ""
                         else:
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('EXPECTING_ATEXT'))
+                            return_status.append(InvalidDiagnosis("EXPECTING_ATEXT"))
 
                     # Folding White Space (FWS)
                     elif token in [Char.CR, Char.SP, Char.HTAB]:
@@ -450,22 +437,22 @@ class ParserValidator(EmailValidator):
                         if token == Char.CR:
                             skip = True
 
-                            if i+1 == raw_length or (to_char(address[i + 1]) !=
-                                                     Char.LF):
+                            if i + 1 == raw_length or (
+                                to_char(address[i + 1]) != Char.LF
+                            ):
                                 # Fatal error
-                                return_status.append(
-                                    InvalidDiagnosis('CR_NO_LF'))
+                                return_status.append(InvalidDiagnosis("CR_NO_LF"))
                                 break
 
                         if element_len == 0:
                             if element_count == 0:
                                 return_status.append(
-                                    DeprecatedDiagnosis('CFWS_NEAR_AT'))
+                                    DeprecatedDiagnosis("CFWS_NEAR_AT")
+                                )
                             else:
-                                return_status.append(
-                                    DeprecatedDiagnosis('FWS'))
+                                return_status.append(DeprecatedDiagnosis("FWS"))
                         else:
-                            return_status.append(CFWSDiagnosis('FWS'))
+                            return_status.append(CFWSDiagnosis("FWS"))
                             # We can't start FWS in the middle of an element,
                             # so this better be the end
                             end_or_die = True
@@ -503,13 +490,15 @@ class ParserValidator(EmailValidator):
                             # valid
                             if context_prior in [Context.COMMENT, Context.FWS]:
                                 return_status.append(
-                                    InvalidDiagnosis('ATEXT_AFTER_CFWS'))
+                                    InvalidDiagnosis("ATEXT_AFTER_CFWS")
+                                )
                             elif context_prior == Context.LITERAL:
                                 return_status.append(
-                                    InvalidDiagnosis('ATEXT_AFTER_DOMLIT'))
+                                    InvalidDiagnosis("ATEXT_AFTER_DOMLIT")
+                                )
                             else:  # pragma: no cover
                                 if diagnose:
-                                    return InvalidDiagnosis('BAD_PARSE')
+                                    return InvalidDiagnosis("BAD_PARSE")
                                 else:
                                     return False
 
@@ -520,21 +509,21 @@ class ParserValidator(EmailValidator):
 
                         if o < 33 or o > 126 or token in Char.SPECIALS:
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('EXPECTING_ATEXT'))
+                            return_status.append(InvalidDiagnosis("EXPECTING_ATEXT"))
                         elif token == Char.HYPHEN:
                             if element_len == 0:
                                 # Hyphens can't be at the beginning of a
                                 # subdomain
                                 # Fatal error
                                 return_status.append(
-                                    InvalidDiagnosis('DOMAINHYPHENSTART'))
+                                    InvalidDiagnosis("DOMAINHYPHENSTART")
+                                )
 
                             hyphen_flag = True
                         elif not (47 < o < 58 or 64 < o < 91 or 96 < o < 123):
                             # Not an RFC 5321 subdomain, but still OK by RFC
                             # 5322
-                            return_status.append(RFC5322Diagnosis('DOMAIN'))
+                            return_status.append(RFC5322Diagnosis("DOMAIN"))
 
                         parse_data[Context.DOMAIN] += token
                         atom_list[Context.DOMAIN][element_count] += token
@@ -556,8 +545,7 @@ class ParserValidator(EmailValidator):
 
                     # End of domain literal
                     if token == Char.CLOSESQBRACKET:
-                        if (max(return_status) <
-                                BaseDiagnosis.CATEGORIES['DEPREC']):
+                        if max(return_status) < BaseDiagnosis.CATEGORIES["DEPREC"]:
                             # Could be a valid RFC 5321 address literal, so
                             # let's check
                             #
@@ -619,7 +607,7 @@ class ParserValidator(EmailValidator):
 
                             max_groups = 8
                             index = False
-                            address_literal = parse_data['literal']
+                            address_literal = parse_data["literal"]
 
                             # Extract IPv4 part from the end of the
                             # address-literal (if there is one)
@@ -629,21 +617,17 @@ class ParserValidator(EmailValidator):
                             )
                             match_ip = re.search(regex, address_literal)
                             if match_ip:
-                                index = address_literal.rfind(
-                                    match_ip.group(0))
+                                index = address_literal.rfind(match_ip.group(0))
                                 if index != 0:
                                     # Convert IPv4 part to IPv6 format for
                                     # further testing
-                                    address_literal = (
-                                        address_literal[0:index] + '0:0')
+                                    address_literal = address_literal[0:index] + "0:0"
 
                             if index == 0 and index is not False:
                                 # Nothing there except a valid IPv4 address
-                                return_status.append(
-                                    RFC5321Diagnosis('ADDRESSLITERAL'))
+                                return_status.append(RFC5321Diagnosis("ADDRESSLITERAL"))
                             elif not address_literal.startswith(Char.IPV6TAG):
-                                return_status.append(
-                                    RFC5322Diagnosis('DOMAINLITERAL'))
+                                return_status.append(RFC5322Diagnosis("DOMAINLITERAL"))
                             else:
                                 ipv6 = address_literal[5:]
                                 # Revision 2.7: Daniel Marschall's new IPv6
@@ -657,11 +641,13 @@ class ParserValidator(EmailValidator):
                                     # groups
                                     if grp_count != max_groups:
                                         return_status.append(
-                                            RFC5322Diagnosis('IPV6_GRPCOUNT'))
+                                            RFC5322Diagnosis("IPV6_GRPCOUNT")
+                                        )
                                 else:
                                     if index != ipv6.rfind(Char.DOUBLECOLON):
                                         return_status.append(
-                                            RFC5322Diagnosis('IPV6_2X2XCOLON'))
+                                            RFC5322Diagnosis("IPV6_2X2XCOLON")
+                                        )
                                     else:
                                         if index in [0, len(ipv6) - 2]:
                                             # RFC 4291 allows :: at the start
@@ -671,37 +657,39 @@ class ParserValidator(EmailValidator):
 
                                         if grp_count > max_groups:
                                             return_status.append(
-                                                RFC5322Diagnosis(
-                                                    'IPV6_MAXGRPS'))
+                                                RFC5322Diagnosis("IPV6_MAXGRPS")
+                                            )
                                         elif grp_count == max_groups:
                                             # Eliding a single "::"
                                             return_status.append(
-                                                RFC5321Diagnosis(
-                                                    'IPV6DEPRECATED'))
+                                                RFC5321Diagnosis("IPV6DEPRECATED")
+                                            )
 
                                 # Revision 2.7: Daniel Marschall's new IPv6
                                 # testing strategy
-                                if (ipv6[0] == Char.COLON and
-                                        ipv6[1] != Char.COLON):
+                                if ipv6[0] == Char.COLON and ipv6[1] != Char.COLON:
                                     # Address starts with a single colon
                                     return_status.append(
-                                        RFC5322Diagnosis('IPV6_COLONSTRT'))
-                                elif (ipv6[-1] == Char.COLON and
-                                        ipv6[-2] != Char.COLON):
+                                        RFC5322Diagnosis("IPV6_COLONSTRT")
+                                    )
+                                elif ipv6[-1] == Char.COLON and ipv6[-2] != Char.COLON:
                                     # Address ends with a single colon
                                     return_status.append(
-                                        RFC5322Diagnosis('IPV6_COLONEND'))
-                                elif ([re.match(r"^[0-9A-Fa-f]{0,4}$", i)
-                                       for i in match_ip].count(None) != 0):
+                                        RFC5322Diagnosis("IPV6_COLONEND")
+                                    )
+                                elif [
+                                    re.match(r"^[0-9A-Fa-f]{0,4}$", i) for i in match_ip
+                                ].count(None) != 0:
                                     # Check for unmatched characters
                                     return_status.append(
-                                        RFC5322Diagnosis('IPV6_BADCHAR'))
+                                        RFC5322Diagnosis("IPV6_BADCHAR")
+                                    )
                                 else:
                                     return_status.append(
-                                        RFC5321Diagnosis('ADDRESSLITERAL'))
+                                        RFC5321Diagnosis("ADDRESSLITERAL")
+                                    )
                         else:
-                            return_status.append(
-                                RFC5322Diagnosis('DOMAINLITERAL'))
+                            return_status.append(RFC5322Diagnosis("DOMAINLITERAL"))
 
                         parse_data[Context.DOMAIN] += token
                         atom_list[Context.DOMAIN][element_count] += token
@@ -709,8 +697,7 @@ class ParserValidator(EmailValidator):
                         context_prior = context
                         context = context_stack.pop()
                     elif token == Char.BACKSLASH:
-                        return_status.append(
-                            RFC5322Diagnosis('DOMLIT_OBSDTEXT'))
+                        return_status.append(RFC5322Diagnosis("DOMLIT_OBSDTEXT"))
                         context_stack.append(context)
                         context = Context.QUOTEDPAIR
                     # Folding White Space (FWS)
@@ -720,13 +707,14 @@ class ParserValidator(EmailValidator):
                         if token == Char.CR:
                             skip = True
 
-                            if (i+1 == raw_length or
-                                    to_char(address[i+1]) != Char.LF):
-                                return_status.append(
-                                    InvalidDiagnosis('CR_NO_LF'))
+                            if (
+                                i + 1 == raw_length
+                                or to_char(address[i + 1]) != Char.LF
+                            ):
+                                return_status.append(InvalidDiagnosis("CR_NO_LF"))
                                 break
 
-                        return_status.append(CFWSDiagnosis('FWS'))
+                        return_status.append(CFWSDiagnosis("FWS"))
 
                         context_stack.append(context)
                         context = Context.FWS
@@ -751,14 +739,12 @@ class ParserValidator(EmailValidator):
                         # CR, LF, SP & HTAB have already been parsed above
                         if o > 127 or o == 0 or token == Char.OPENSQBRACKET:
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('EXPECTING_DTEXT'))
+                            return_status.append(InvalidDiagnosis("EXPECTING_DTEXT"))
                             break
                         elif o < 33 or o == 127:
-                            return_status.append(
-                                RFC5322Diagnosis('DOMLIT_OBSDTEXT'))
+                            return_status.append(RFC5322Diagnosis("DOMLIT_OBSDTEXT"))
 
-                        parse_data['literal'] += token
+                        parse_data["literal"] += token
                         parse_data[Context.DOMAIN] += token
                         atom_list[Context.DOMAIN][element_count] += token
                         element_len += 1
@@ -786,10 +772,11 @@ class ParserValidator(EmailValidator):
                         if token == Char.CR:
                             skip = True
 
-                            if (i+1 == raw_length or
-                                    to_char(address[i+1]) != Char.LF):
-                                return_status.append(
-                                    InvalidDiagnosis('CR_NO_LF'))
+                            if (
+                                i + 1 == raw_length
+                                or to_char(address[i + 1]) != Char.LF
+                            ):
+                                return_status.append(InvalidDiagnosis("CR_NO_LF"))
                                 break
 
                         # http://tools.ietf.org/html/rfc5322#section-3.2.2
@@ -806,7 +793,7 @@ class ParserValidator(EmailValidator):
                         atom_list[Context.LOCALPART][element_count] += Char.SP
                         element_len += 1
 
-                        return_status.append(CFWSDiagnosis('FWS'))
+                        return_status.append(CFWSDiagnosis("FWS"))
                         context_stack.append(context)
                         context = Context.FWS
                         token_prior = token
@@ -837,11 +824,9 @@ class ParserValidator(EmailValidator):
 
                         if o > 127 or o == 0 or o == 10:
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('EXPECTING_QTEXT'))
+                            return_status.append(InvalidDiagnosis("EXPECTING_QTEXT"))
                         elif o < 32 or o == 127:
-                            return_status.append(
-                                DeprecatedDiagnosis('QTEXT'))
+                            return_status.append(DeprecatedDiagnosis("QTEXT"))
 
                         parse_data[Context.LOCALPART] += token
                         atom_list[Context.LOCALPART][element_count] += token
@@ -872,11 +857,10 @@ class ParserValidator(EmailValidator):
 
                     if o > 127:
                         # Fatal error
-                        return_status.append(
-                            InvalidDiagnosis('EXPECTING_QPAIR'))
+                        return_status.append(InvalidDiagnosis("EXPECTING_QPAIR"))
                     elif (o < 31 and o != 9) or o == 127:
                         # SP & HTAB are allowed
-                        return_status.append(DeprecatedDiagnosis('QP'))
+                        return_status.append(DeprecatedDiagnosis("QP"))
 
                     # At this point we know where this qpair occurred so
                     # we could check to see if the character actually
@@ -885,7 +869,7 @@ class ParserValidator(EmailValidator):
                     #   the sending system SHOULD transmit the
                     #   form that uses the minimum quoting possible.
                     context_prior = context
-                    context = context_stack.pop()   # End of qpair
+                    context = context_stack.pop()  # End of qpair
                     token = Char.BACKSLASH + token
 
                     if context == Context.COMMENT:
@@ -904,7 +888,7 @@ class ParserValidator(EmailValidator):
                         element_len += 2
                     else:  # pragma: no cover
                         if diagnose:
-                            return InvalidDiagnosis('BAD_PARSE')
+                            return InvalidDiagnosis("BAD_PARSE")
                         else:
                             return False
                 # -------------------------------------------------------
@@ -936,13 +920,14 @@ class ParserValidator(EmailValidator):
                         if token == Char.CR:
                             skip = True
 
-                            if (i+1 == raw_length or
-                                    to_char(address[i+1]) != Char.LF):
-                                return_status.append(
-                                    InvalidDiagnosis('CR_NO_LF'))
+                            if (
+                                i + 1 == raw_length
+                                or to_char(address[i + 1]) != Char.LF
+                            ):
+                                return_status.append(InvalidDiagnosis("CR_NO_LF"))
                                 break
 
-                        return_status.append(CFWSDiagnosis('FWS'))
+                        return_status.append(CFWSDiagnosis("FWS"))
 
                         context_stack.append(context)
                         context = Context.FWS
@@ -968,11 +953,10 @@ class ParserValidator(EmailValidator):
 
                         if o > 127 or o == 0 or o == 10:
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('EXPECTING_CTEXT'))
+                            return_status.append(InvalidDiagnosis("EXPECTING_CTEXT"))
                             break
                         elif o < 32 or o == 127:
-                            return_status.append(DeprecatedDiagnosis('CTEXT'))
+                            return_status.append(DeprecatedDiagnosis("CTEXT"))
 
                 # -------------------------------------------------------
                 # Folding White Space (FWS)
@@ -996,16 +980,14 @@ class ParserValidator(EmailValidator):
                     if token_prior == Char.CR:
                         if token == Char.CR:
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('FWS_CRLF_X2'))
+                            return_status.append(InvalidDiagnosis("FWS_CRLF_X2"))
                             break
 
                         if crlf_count != -1:
                             crlf_count += 1
                             if crlf_count > 1:
                                 # Multiple folds = obsolete FWS
-                                return_status.append(
-                                    DeprecatedDiagnosis('FWS'))
+                                return_status.append(DeprecatedDiagnosis("FWS"))
                         else:
                             crlf_count = 1
 
@@ -1014,17 +996,15 @@ class ParserValidator(EmailValidator):
                     if token == Char.CR:
                         skip = True
 
-                        if (i+1 == raw_length or
-                                to_char(address[i+1]) != Char.LF):
-                            return_status.append(InvalidDiagnosis('CR_NO_LF'))
+                        if i + 1 == raw_length or to_char(address[i + 1]) != Char.LF:
+                            return_status.append(InvalidDiagnosis("CR_NO_LF"))
                             break
                     elif token in [Char.SP, Char.HTAB]:
                         pass
                     else:
                         if token_prior == Char.CR:
                             # Fatal error
-                            return_status.append(
-                                InvalidDiagnosis('FWS_CRLF_END'))
+                            return_status.append(InvalidDiagnosis("FWS_CRLF_END"))
                             break
 
                         if crlf_count != -1:
@@ -1044,44 +1024,44 @@ class ParserValidator(EmailValidator):
                 # -------------------------------------------------------
                 else:  # pragma: no cover
                     if diagnose:
-                        return InvalidDiagnosis('BAD_PARSE')
+                        return InvalidDiagnosis("BAD_PARSE")
                     else:
                         return False
 
             # No point in going on if we've got a fatal error
-            if max(return_status) > BaseDiagnosis.CATEGORIES['RFC5322']:
+            if max(return_status) > BaseDiagnosis.CATEGORIES["RFC5322"]:
                 break
 
         # Some simple final tests
-        if max(return_status) < BaseDiagnosis.CATEGORIES['RFC5322']:
+        if max(return_status) < BaseDiagnosis.CATEGORIES["RFC5322"]:
             if context == Context.QUOTEDSTRING:
                 # Fatal error
-                return_status.append(InvalidDiagnosis('UNCLOSEDQUOTEDSTR'))
+                return_status.append(InvalidDiagnosis("UNCLOSEDQUOTEDSTR"))
             elif context == Context.QUOTEDPAIR:
                 # Fatal error
-                return_status.append(InvalidDiagnosis('BACKSLASHEND'))
+                return_status.append(InvalidDiagnosis("BACKSLASHEND"))
             elif context == Context.COMMENT:
                 # Fatal error
-                return_status.append(InvalidDiagnosis('UNCLOSEDCOMMENT'))
+                return_status.append(InvalidDiagnosis("UNCLOSEDCOMMENT"))
             elif context == Context.LITERAL:
                 # Fatal error
-                return_status.append(InvalidDiagnosis('UNCLOSEDDOMLIT'))
+                return_status.append(InvalidDiagnosis("UNCLOSEDDOMLIT"))
             elif token == Char.CR:
                 # Fatal error
-                return_status.append(InvalidDiagnosis('FWS_CRLF_END'))
-            elif parse_data[Context.DOMAIN] == '':
+                return_status.append(InvalidDiagnosis("FWS_CRLF_END"))
+            elif parse_data[Context.DOMAIN] == "":
                 # Fatal error
-                return_status.append(InvalidDiagnosis('NODOMAIN'))
+                return_status.append(InvalidDiagnosis("NODOMAIN"))
             elif element_len == 0:
                 # Fatal error
-                return_status.append(InvalidDiagnosis('DOT_END'))
+                return_status.append(InvalidDiagnosis("DOT_END"))
             elif hyphen_flag:
                 # Fatal error
-                return_status.append(InvalidDiagnosis('DOMAINHYPHENEND'))
+                return_status.append(InvalidDiagnosis("DOMAINHYPHENEND"))
             # http://tools.ietf.org/html/rfc5321#section-4.5.3.1.2
             # The maximum total length of a domain name or number is 255 octets
             elif len(parse_data[Context.DOMAIN]) > 255:
-                return_status.append(RFC5322Diagnosis('DOMAIN_TOOLONG'))
+                return_status.append(RFC5322Diagnosis("DOMAIN_TOOLONG"))
             # http://tools.ietf.org/html/rfc5321#section-4.1.2
             #   Forward-path   = Path
             #
@@ -1101,13 +1081,17 @@ class ParserValidator(EmailValidator):
             #   addresses that do not fit in those fields are not normally
             #   useful, the upper limit on address lengths should normally be
             #   considered to be 254.
-            elif len(parse_data[Context.LOCALPART] + Char.AT +
-                     parse_data[Context.DOMAIN]) > 254:
-                return_status.append(RFC5322Diagnosis('TOOLONG'))
+            elif (
+                len(
+                    parse_data[Context.LOCALPART] + Char.AT + parse_data[Context.DOMAIN]
+                )
+                > 254
+            ):
+                return_status.append(RFC5322Diagnosis("TOOLONG"))
             # http://tools.ietf.org/html/rfc1035#section-2.3.4
             # labels           63 octets or less
             elif element_len > 63:
-                return_status.append(RFC5322Diagnosis('LABEL_TOOLONG'))
+                return_status.append(RFC5322Diagnosis("LABEL_TOOLONG"))
 
         return_status = list(set(return_status))
         final_status = max(return_status)
@@ -1116,7 +1100,7 @@ class ParserValidator(EmailValidator):
             # Remove redundant ValidDiagnosis
             return_status.pop(0)
 
-        parse_data['status'] = return_status
+        parse_data["status"] = return_status
 
         if final_status < threshold:
             final_status = ValidDiagnosis()
@@ -1124,4 +1108,4 @@ class ParserValidator(EmailValidator):
         if diagnose:
             return final_status
         else:
-            return final_status < BaseDiagnosis.CATEGORIES['THRESHOLD']
+            return final_status < BaseDiagnosis.CATEGORIES["THRESHOLD"]

--- a/pyisemail/version.py
+++ b/pyisemail/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.3.2'
+VERSION = "1.3.2"

--- a/setup.py
+++ b/setup.py
@@ -18,18 +18,6 @@ def get_version():
     raise RuntimeError('No version information found.')
 
 
-def tests_require():
-    requirements = [
-        "coverage",
-        "testtools >= 0.9.21",
-        "testscenarios >= 0.3"
-    ]
-
-    if sys.version_info[0] < 3:
-        requirements.append("mock >= 1.0.1")
-
-    return requirements
-
 setup(
     name="pyIsEmail",
     version=get_version(),
@@ -61,7 +49,7 @@ setup(
     install_requires=[
         "dnspython >= 1.15.0",
     ],
-    tests_require=tests_require(),
+    tests_require=["coverage", "pytest"],
     test_suite="tests",
     **kwargs
 )

--- a/setup.py
+++ b/setup.py
@@ -11,18 +11,18 @@ kwargs = {}
 
 def get_version():
     basedir = os.path.dirname(__file__)
-    with open(os.path.join(basedir, 'pyisemail/version.py')) as f:
+    with open(os.path.join(basedir, "pyisemail/version.py")) as f:
         locals = {}
         exec(f.read(), locals)
-        return locals['VERSION']
-    raise RuntimeError('No version information found.')
+        return locals["VERSION"]
+    raise RuntimeError("No version information found.")
 
 
 setup(
     name="pyIsEmail",
     version=get_version(),
     description="Simple, robust email validation",
-    long_description=open('README.rst').read(),
+    long_description=open("README.rst").read(),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -35,16 +35,14 @@ setup(
         "Topic :: Communications :: Email",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    keywords=['email', 'validation'],
+    keywords=["email", "validation"],
     author="Michael Herold",
     author_email="opensource@michaeljherold.com",
     url="https://github.com/michaelherold/pyIsEmail",
     license="MIT",
     packages=["pyisemail", "pyisemail.diagnosis", "pyisemail.validators"],
     include_package_data=True,
-    exclude_package_data={
-        '': ['.gitignore']
-    },
+    exclude_package_data={"": [".gitignore"]},
     zip_safe=False,
     install_requires=[
         "dnspython >= 1.15.0",


### PR DESCRIPTION
The way the code in the library has been formatted has bothered me for
years. Now that there's a reasonable option for auto-formatting, I'm
opting to use it.