### PR TITLE
replace resolver.query with resolver.resolve

### DIFF
--- a/pyisemail/validators/dns_validator.py
+++ b/pyisemail/validators/dns_validator.py
@@ -1,5 +1,6 @@
 import dns.exception
 import dns.resolver
+from dns.rdatatype import MX
 from pyisemail.diagnosis import DNSDiagnosis, RFC5321Diagnosis, ValidDiagnosis
 
 
@@ -36,7 +37,7 @@ class DNSValidator(object):
         # we will raise a warning because we didn't immediately find an MX
         # record.
         try:
-            dns.resolver.query(domain, "MX")
+            dns.resolver.resolve(domain, MX)
             dns_checked = True
         except (dns.resolver.NXDOMAIN, dns.name.NameTooLong):
             # Domain can't be found in DNS
@@ -52,8 +53,7 @@ class DNSValidator(object):
             return_status.append(DNSDiagnosis("NO_MX_RECORD"))
 
             try:
-                # TODO: See if we can/need to narrow to A / CNAME
-                dns.resolver.query(domain)
+                dns.resolver.resolve(domain)
             except dns.resolver.NoAnswer:
                 # No usable records for the domain can be found
                 return_status.append(DNSDiagnosis("NO_RECORD"))

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     exclude_package_data={"": [".gitignore"]},
     zip_safe=False,
     install_requires=[
-        "dnspython >= 1.15.0",
+        "dnspython >= 2.0.0",
     ],
     tests_require=["coverage", "pytest"],
     test_suite="tests",

--- a/tests/test_is_email.py
+++ b/tests/test_is_email.py
@@ -1,8 +1,13 @@
-import dns.resolver
 import pytest
+
+import dns.resolver
 from pyisemail import is_email
-from pyisemail.diagnosis import (BaseDiagnosis, DNSDiagnosis, GTLDDiagnosis,
-                                 ValidDiagnosis)
+from pyisemail.diagnosis import (
+    BaseDiagnosis,
+    DNSDiagnosis,
+    GTLDDiagnosis,
+    ValidDiagnosis,
+)
 
 from tests.validators import create_diagnosis, get_scenarios
 

--- a/tests/test_is_email.py
+++ b/tests/test_is_email.py
@@ -1,13 +1,9 @@
-import pytest
-
 import dns.resolver
+import pytest
 from pyisemail import is_email
-from pyisemail.diagnosis import (
-    BaseDiagnosis,
-    DNSDiagnosis,
-    GTLDDiagnosis,
-    ValidDiagnosis,
-)
+from pyisemail.diagnosis import (BaseDiagnosis, DNSDiagnosis, GTLDDiagnosis,
+                                 ValidDiagnosis)
+
 from tests.validators import create_diagnosis, get_scenarios
 
 scenarios = get_scenarios("tests.xml")
@@ -45,7 +41,7 @@ def test_with_diagnosis(test_id, address, diagnosis):
 
 
 def test_dns_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", side_effect)
 
     result = is_email("test@example.com", check_dns=True)
     expected = False
@@ -54,7 +50,7 @@ def test_dns_without_diagnosis(monkeypatch):
 
 
 def test_dns_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", side_effect)
 
     result = is_email("test@example.com", check_dns=True, diagnose=True)
     expected = DNSDiagnosis("NO_RECORD")

--- a/tests/validators/test_dns_validator.py
+++ b/tests/validators/test_dns_validator.py
@@ -1,9 +1,8 @@
-import pytest
 import dns.name
 import dns.resolver
+import pytest
 from pyisemail.diagnosis import DNSDiagnosis, RFC5321Diagnosis, ValidDiagnosis
 from pyisemail.validators import DNSValidator
-
 
 is_valid = DNSValidator().is_valid
 
@@ -33,108 +32,108 @@ def timeout_side_effect(*_):
 
 
 def test_working_mx_record_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", no_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", no_side_effect)
 
     assert is_valid("example.com")
 
 
 def test_working_mx_record_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", no_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", no_side_effect)
 
     assert is_valid("example.com", diagnose=True) == ValidDiagnosis()
 
 
 def test_non_existant_mx_record_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", nx_domain_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", nx_domain_side_effect)
 
     assert not is_valid("example.com")
 
 
 def test_non_existant_mx_record_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", nx_domain_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", nx_domain_side_effect)
 
     assert is_valid("example.com", diagnose=True) == DNSDiagnosis("NO_RECORD")
 
 
 def test_domain_too_long_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", too_long_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", too_long_side_effect)
 
     assert not is_valid("example.com")
 
 
 def test_domain_too_long_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", too_long_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", too_long_side_effect)
 
     assert is_valid("example.com", diagnose=True) == DNSDiagnosis("NO_RECORD")
 
 
 def test_no_record_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", too_long_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", too_long_side_effect)
 
     assert not is_valid("example.com")
 
 
 def test_no_record_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", too_long_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", too_long_side_effect)
 
     assert is_valid("example.com", diagnose=True) == DNSDiagnosis("NO_RECORD")
 
 
 def test_no_mx_on_tld_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", nx_domain_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", nx_domain_side_effect)
 
     assert not is_valid("com")
 
 
 def test_no_mx_on_tld_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", nx_domain_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", nx_domain_side_effect)
 
     assert is_valid("com", diagnose=True) == DNSDiagnosis("NO_RECORD")
 
 
 def test_no_records_on_tld_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", no_record_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", no_record_side_effect)
 
     assert not is_valid("com")
 
 
 def test_no_records_on_tld_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", no_record_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", no_record_side_effect)
 
     assert is_valid("com", diagnose=True) == RFC5321Diagnosis("TLD")
 
 
 def test_no_records_on_numeric_tld_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", no_record_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", no_record_side_effect)
 
     assert not is_valid("iana.123")
 
 
 def test_no_records_on_numeric_tld_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", no_record_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", no_record_side_effect)
 
     assert is_valid("iana.123", diagnose=True) == RFC5321Diagnosis("TLDNUMERIC")
 
 
 def test_no_nameservers_respond_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", no_ns_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", no_ns_side_effect)
 
     assert not is_valid("example.com")
 
 
 def test_no_nameservers_respond_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", no_ns_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", no_ns_side_effect)
 
     assert is_valid("example.com", diagnose=True) == DNSDiagnosis("NO_NAMESERVERS")
 
 
 def test_dns_timeout_without_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", timeout_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", timeout_side_effect)
 
     assert not is_valid("example.com")
 
 
 def test_dns_timeout_with_diagnosis(monkeypatch):
-    monkeypatch.setattr(dns.resolver, "query", timeout_side_effect)
+    monkeypatch.setattr(dns.resolver, "resolve", timeout_side_effect)
 
     assert is_valid("example.com", diagnose=True) == DNSDiagnosis("DNS_TIMEDOUT")


### PR DESCRIPTION
Thanks so much for this great package. The dns.resolver.query function is deprecated https://github.com/rthalley/dnspython/blob/master/doc/whatsnew.rst#200 so this request is just aiming to replace it with the recommended dns.resolver.resolve.