### PR TITLE
Update supported versions and Black version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black==21.9b0
+          pip install black==21.12b0
 
       - name: Check formatting
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,12 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9
+          - "3.10"
           - pypy-3.7
+          - pypy-3.8
     steps:
       - uses: actions/checkout@v2
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 coverage==5.5
-pytest==6.2.2
+pytest==6.2.5


### PR DESCRIPTION
- v3.6 released on 2016-10-23, end-of-life on 2021-10-23
- v3.7 released on 2018-07-27, supported till 2023-06-27
- v3.8 released on 2019-10-14, supported till 2024-10-14
- v3.9 released on 2020-10-05, supported till 2025-10-05
- v3.10 released on 2021-10-04, supported till 2026-10-04

Presumably, PyPy supports their implementation till the end-of-life for
CPython's version? It's not clear, but they dropped support for v3.6 a
year earlier than CPython.

- pypy3.7 released on 2020-09-24
- pypy3.8 released on 2021-10-17