### PR TITLE
Bump black due to click 8 incompatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black==21.12b0
+          pip install black==22.10.0
 
       - name: Check formatting
         run: |


### PR DESCRIPTION
`click` 8 changed its API so versions of `black` prior to 22.3.0 stopped working. This change bumps `black` so we are able to run it again.