### PR TITLE
Add bandit and isort linters

### DIFF
--- a/pyisemail/__init__.py
+++ b/pyisemail/__init__.py
@@ -2,9 +2,7 @@ from pyisemail.__about__ import __version__
 from pyisemail.diagnosis import BaseDiagnosis
 from pyisemail.email_validator import EmailValidator
 from pyisemail.reference import Reference
-from pyisemail.validators import DNSValidator
-from pyisemail.validators import GTLDValidator
-from pyisemail.validators import ParserValidator
+from pyisemail.validators import DNSValidator, GTLDValidator, ParserValidator
 
 __all__ = ["is_email"]
 

--- a/pyisemail/validators/dns_validator.py
+++ b/pyisemail/validators/dns_validator.py
@@ -1,6 +1,7 @@
 import dns.exception
 import dns.resolver
 from dns.rdatatype import MX
+
 from pyisemail.diagnosis import DNSDiagnosis, RFC5321Diagnosis, ValidDiagnosis
 
 

--- a/pyisemail/validators/parser_validator.py
+++ b/pyisemail/validators/parser_validator.py
@@ -1,10 +1,16 @@
 import re
 import sys
+
 from pyisemail import EmailValidator
-from pyisemail.diagnosis import BaseDiagnosis, CFWSDiagnosis
-from pyisemail.diagnosis import DeprecatedDiagnosis
-from pyisemail.diagnosis import InvalidDiagnosis, RFC5321Diagnosis
-from pyisemail.diagnosis import RFC5322Diagnosis, ValidDiagnosis
+from pyisemail.diagnosis import (
+    BaseDiagnosis,
+    CFWSDiagnosis,
+    DeprecatedDiagnosis,
+    InvalidDiagnosis,
+    RFC5321Diagnosis,
+    RFC5322Diagnosis,
+    ValidDiagnosis,
+)
 from pyisemail.utils import enum
 
 __all__ = ["ParserValidator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ Homepage = "https://github.com/michaelherold/pyIsEmail"
 Source = "https://github.com/michaelherold/pyIsEmail"
 Tracker = "https://github.com/michaelherold/pyIsEmail/issues"
 
+[tool.bandit]
+recursive = true
+exclude_dirs = ["tests"]
+skips = ["B105"]
+
 [tool.black]
 include = '\.pyi?$'
 skip-string-normalization = true
@@ -49,6 +54,14 @@ omit = ["*test*"]
 
 [tool.coverage.run]
 source = ["pyisemail"]
+
+[tool.isort]
+default_section = "THIRDPARTY"
+force_grid_wrap = 0
+include_trailing_comma = true
+known_first_party = ["hatch", "hatchling"]
+multi_line_output = 3
+use_parentheses = true
 
 [tool.hatch.version]
 path = "pyisemail/__about__.py"
@@ -80,22 +93,29 @@ dependencies = [
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
+    "bandit[toml]==1.7.4",
     "black==22.10.0",
+    "isort==5.10.1",
 ]
 
 [tool.hatch.envs.lint.scripts]
 all = [
     "fmt",
+    "security",
 ]
 fmt = [
     "black --quiet {args:.}",
+    "isort --quiet {args:.}",
     "style",
 ]
 lint = [
-     "style",
+    "security",
+    "style",
 ]
+security = "bandit --configfile pyproject.toml --quiet --recursive {args:.}"
 style = [
     "black --quiet --check --diff {args:.}",
+    "isort --quiet --check-only --diff {args:.}"
 ]
 
 [[tool.hatch.envs.test.matrix]]

--- a/tests/diagnosis/test_base_diagnosis.py
+++ b/tests/diagnosis/test_base_diagnosis.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyisemail.diagnosis import BaseDiagnosis
 
 

--- a/tests/test_email_validator.py
+++ b/tests/test_email_validator.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyisemail import EmailValidator
 
 

--- a/tests/test_is_email.py
+++ b/tests/test_is_email.py
@@ -1,6 +1,6 @@
+import dns.resolver
 import pytest
 
-import dns.resolver
 from pyisemail import is_email
 from pyisemail.diagnosis import (
     BaseDiagnosis,
@@ -8,7 +8,6 @@ from pyisemail.diagnosis import (
     GTLDDiagnosis,
     ValidDiagnosis,
 )
-
 from tests.validators import create_diagnosis, get_scenarios
 
 scenarios = get_scenarios("tests.xml")

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyisemail import Reference
 
 

--- a/tests/validators/__init__.py
+++ b/tests/validators/__init__.py
@@ -1,10 +1,16 @@
 import os
 import sys
 import xml.etree.ElementTree as ET
-from pyisemail.diagnosis import CFWSDiagnosis, DeprecatedDiagnosis
-from pyisemail.diagnosis import DNSDiagnosis, InvalidDiagnosis
-from pyisemail.diagnosis import RFC5321Diagnosis, RFC5322Diagnosis
-from pyisemail.diagnosis import ValidDiagnosis
+
+from pyisemail.diagnosis import (
+    CFWSDiagnosis,
+    DeprecatedDiagnosis,
+    DNSDiagnosis,
+    InvalidDiagnosis,
+    RFC5321Diagnosis,
+    RFC5322Diagnosis,
+    ValidDiagnosis,
+)
 
 __all__ = ["create_diagnosis", "get_scenarios"]
 

--- a/tests/validators/test_dns_validator.py
+++ b/tests/validators/test_dns_validator.py
@@ -1,7 +1,9 @@
 import time
+
 import dns.name
 import dns.resolver
 import pytest
+
 from pyisemail.diagnosis import DNSDiagnosis, RFC5321Diagnosis, ValidDiagnosis
 from pyisemail.validators import DNSValidator
 

--- a/tests/validators/test_parser_validator.py
+++ b/tests/validators/test_parser_validator.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyisemail.diagnosis import BaseDiagnosis
 from pyisemail.validators import ParserValidator
 from tests.validators import create_diagnosis, get_scenarios


### PR DESCRIPTION
Bandit gives some basic security scanning, which is beneficial for an infrastructure library such as this one.

isort takes the hassle out of organizing your imports, which is something that Black does not take a strong stance on.