### PR TITLE
Remove leftover setup.cfg file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1


### PR DESCRIPTION
I missed removing this with the move over to Hatch. It doesn't need to exist anymore.

Relates to #25