### PR TITLE
Constrain to Pythons >= 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 dependencies = [
     "dnspython >= 2.0.0",
 ]
+requires-python = ">=3.7"
 
 [project.urls]
 Homepage = "https://github.com/michaelherold/pyIsEmail"


### PR DESCRIPTION
This wasn't set when initially importing the configuration with Hatch so it was building a universal wheel, which is incorrect.